### PR TITLE
Fix drop_path and NCRP prior bugs

### DIFF
--- a/hlda/sampler.py
+++ b/hlda/sampler.py
@@ -60,16 +60,13 @@ class NCRPNode(object):
         return node
 
     def drop_path(self):
-        ''' Removes a document from a path starting from this node '''
+        ''' Removes a document from a path starting from this node (leaf) upwards '''
         node = self
-        node.customers -= 1
-        if node.customers == 0:
-            node.parent.remove(node)
-        for level in range(1, self.num_levels): # skip the root
-            node = node.parent
+        while node is not None:
             node.customers -= 1
-            if node.customers == 0:
+            if node.customers == 0 and node.parent is not None:
                 node.parent.remove(node)
+            node = node.parent
 
     def remove(self, node):
         ''' Removes a child node '''
@@ -281,12 +278,17 @@ class HierarchicalLDA(object):
 
     def calculate_ncrp_prior(self, node_weights, node, weight):
         ''' Calculates the prior on the path according to the nested CRP '''
-
         for child in node.children:
-            child_weight = log( float(child.customers) / (node.customers + self.gamma) )
-            self.calculate_ncrp_prior(node_weights, child, weight + child_weight)
+            child_weight = log(float(child.customers) /
+                               (node.customers + self.gamma))
+            self.calculate_ncrp_prior(node_weights, child,
+                                      weight + child_weight)
 
-        node_weights[node] = weight + log( self.gamma / (node.customers + self.gamma))
+        if node.is_leaf():
+            node_weights[node] = weight
+        else:
+            node_weights[node] = weight + log(self.gamma /
+                                              (node.customers + self.gamma))
 
     def calculate_doc_likelihood(self, node_weights, level_word_counts):
 

--- a/tests/test_synthetic_hlda.py
+++ b/tests/test_synthetic_hlda.py
@@ -42,3 +42,35 @@ def test_hlda_runs_on_synthetic_data():
 
     assert len(hlda.document_leaves) == n_docs
     assert hlda.root_node.customers == n_docs
+
+def test_tree_invariants_during_sampling():
+    n_topics = 3
+    vocab_size = 9
+    doc_len = 20
+    n_docs = 5
+    corpus, vocab = generate_corpus(n_topics, vocab_size, doc_len, n_docs)
+
+    hlda = HierarchicalLDA(corpus, vocab, alpha=1.0, gamma=1.0, eta=1.0,
+                           num_levels=3, seed=0, verbose=False)
+
+    total_nodes_history = []
+    root_cust_history = []
+    for _ in range(20):
+        for d in range(n_docs):
+            hlda.sample_path(d)
+        for d in range(n_docs):
+            hlda.sample_topics(d)
+        total_nodes_history.append(hlda.root_node.total_nodes)
+        root_cust_history.append(hlda.root_node.customers)
+        for leaf in hlda.document_leaves.values():
+            assert leaf.level == hlda.num_levels - 1
+            node = leaf
+            depth = 0
+            while node.parent is not None:
+                node = node.parent
+                depth += 1
+            assert depth == hlda.num_levels - 1
+
+    assert all(cust == n_docs for cust in root_cust_history)
+    diffs = np.diff(total_nodes_history)
+    assert (diffs > 0).any() and (diffs < 0).any()


### PR DESCRIPTION
## Summary
- fix removing documents from a path so the root is not accidentally deleted
- correct NCRP prior calculation so leaf nodes do not include the gamma term
- verify tree invariants during sampling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840b3e0609c83268fd9d2a2e6f7040e