### PR TITLE
Add deterministic BBC demo test

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,4 +23,5 @@ Installation
 
 - Simply use `pip install hlda` to install the package.
 - An example notebook that infers the hierarchical topics on the BBC Insight corpus can be found in [notebooks/bbc_test.ipynb](notebooks/bbc_test.ipynb).
+- A command line demonstration that mirrors the notebook is available at [scripts/bbc_demo.py](scripts/bbc_demo.py).
 

--- a/hlda/sampler.py
+++ b/hlda/sampler.py
@@ -43,7 +43,13 @@ class NCRPNode(object):
 
     def add_child(self):
         ''' Adds a child to the next level of this node '''
-        node = NCRPNode(self.num_levels, self.vocab, parent=self, level=self.level+1)
+        node = NCRPNode(
+            self.num_levels,
+            self.vocab,
+            parent=self,
+            level=self.level + 1,
+            random_state=self.random_state,
+        )
         self.children.append(node)
         NCRPNode.total_nodes += 1
         return node
@@ -150,7 +156,11 @@ class HierarchicalLDA(object):
         # initialize and fill the topic pointer arrays for
         # every document. Set everything to the single path that
         # we added earlier.
-        self.root_node = NCRPNode(self.num_levels, self.vocab)
+        self.root_node = NCRPNode(
+            self.num_levels,
+            self.vocab,
+            random_state=self.random_state,
+        )
         self.document_leaves = {}                                   # currently selected path (ie leaf node) through the NCRP tree
         self.levels = np.zeros(self.num_documents, dtype=object) # indexed < doc, token >
         for d in range(len(self.corpus)):

--- a/scripts/bbc_demo.py
+++ b/scripts/bbc_demo.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Command-line demo for hierarchical LDA using the BBC dataset."""
+
+import argparse
+import glob
+import os
+import re
+
+
+from hlda.sampler import HierarchicalLDA
+
+# A small set of English stopwords. This keeps the demo self-contained.
+STOPWORDS = {
+    "the",
+    "and",
+    "for",
+    "are",
+    "with",
+    "that",
+    "this",
+    "from",
+    "you",
+    "was",
+    "have",
+    "not",
+    "but",
+    "they",
+    "his",
+    "her",
+    "she",
+    "has",
+    "had",
+    "him",
+    "its",
+    "our",
+    "their",
+    "about",
+    "into",
+    "after",
+    "these",
+    "those",
+    "them",
+    "over",
+    "such",
+    "also",
+    "will",
+    "would",
+    "can",
+    "could",
+    "should",
+    "may",
+    "might",
+    "your",
+    "than",
+    "when",
+    "where",
+    "what",
+    "which",
+    "who",
+    "whom",
+    "why",
+    "how",
+}
+
+TOKEN_RE = re.compile(r"[a-zA-Z]{3,}")
+
+
+def load_documents(data_dir: str):
+    """Load and preprocess all text files under *data_dir*."""
+    corpus = []
+    for filename in sorted(glob.glob(os.path.join(data_dir, "*.txt"))):
+        with open(filename, "r", encoding="utf-8", errors="ignore") as f:
+            text = f.read().lower()
+        tokens = [t for t in TOKEN_RE.findall(text) if t not in STOPWORDS]
+        corpus.append(tokens)
+    return corpus
+
+
+def build_vocab(corpus):
+    vocab = sorted({word for doc in corpus for word in doc})
+    index = {w: i for i, w in enumerate(vocab)}
+    return vocab, index
+
+
+def convert_corpus(corpus, index):
+    new_corpus = []
+    for doc in corpus:
+        new_corpus.append([index[w] for w in doc])
+    return new_corpus
+
+
+def run_demo(args):
+    corpus = load_documents(args.data_dir)
+    vocab, index = build_vocab(corpus)
+    int_corpus = convert_corpus(corpus, index)
+
+    hlda = HierarchicalLDA(
+        int_corpus,
+        vocab,
+        alpha=args.alpha,
+        gamma=args.gamma,
+        eta=args.eta,
+        num_levels=args.num_levels,
+        seed=args.seed,
+    )
+
+    hlda.estimate(
+        args.iterations,
+        display_topics=args.display_topics,
+        n_words=args.n_words,
+        with_weights=False,
+    )
+
+    print("\nFinal topic hierarchy:")
+    hlda.print_nodes(args.n_words, with_weights=False)
+
+    return hlda
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Run hierarchical LDA on the BBC sample dataset"
+    )
+    parser.add_argument(
+        "--data-dir", default="bbc/tech", help="Directory containing BBC .txt files"
+    )
+    parser.add_argument("--iterations", type=int, default=100, help="Number of Gibbs samples")
+    parser.add_argument(
+        "--display-topics", type=int, default=50, help="Report topics every N iterations"
+    )
+    parser.add_argument(
+        "--n-words", type=int, default=5, help="Number of words to display per topic"
+    )
+    parser.add_argument(
+        "--num-levels", type=int, default=3, help="Depth of the topic hierarchy"
+    )
+    parser.add_argument("--alpha", type=float, default=10.0, help="Alpha hyperparameter")
+    parser.add_argument("--gamma", type=float, default=1.0, help="Gamma hyperparameter")
+    parser.add_argument("--eta", type=float, default=0.1, help="Eta hyperparameter")
+    parser.add_argument("--seed", type=int, default=0, help="Random seed")
+
+    args = parser.parse_args()
+    run_demo(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_bbc_demo.py
+++ b/tests/test_bbc_demo.py
@@ -1,0 +1,27 @@
+import argparse
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+from scripts import bbc_demo
+
+BBC_DIR = os.path.join(os.path.dirname(__file__), '..', 'bbc', 'tech')
+
+
+def test_bbc_demo_deterministic():
+    args = argparse.Namespace(
+        data_dir=BBC_DIR,
+        iterations=2,
+        display_topics=2,
+        n_words=3,
+        num_levels=3,
+        alpha=10.0,
+        gamma=1.0,
+        eta=0.1,
+        seed=0,
+    )
+    hlda = bbc_demo.run_demo(args)
+    assert hlda.root_node.total_nodes == 15
+    assert hlda.root_node.customers == 401
+    assert hlda.num_documents == 401
+


### PR DESCRIPTION
## Summary
- propagate random state when creating NCRP nodes for reproducibility
- tweak BBC demo script and return sampler object
- add regression test to ensure BBC demo results are stable

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6840b6e2d7bc8326b131a135b261dc40