### PR TITLE
Enable word column names in synthetic data

### DIFF
--- a/notebooks/synth_data.py
+++ b/notebooks/synth_data.py
@@ -5,114 +5,138 @@ import numpy as np
 import pylab as plt
 import pandas as pd
 
+
 class HldaDataGenerator(object):
-    
-        def __init__(self, alpha, make_plot=False):
-            self.alpha = alpha
-            self.make_plot = make_plot
 
-        def generate_word_dists(self, n_topics, vocab_size, document_length):
-                        
-            width = vocab_size/n_topics
-            word_dists = np.zeros((n_topics, vocab_size))
-     
-            for k in range(n_topics):
-                temp = np.zeros((n_topics, width))
-                temp[k, :] = int(document_length / width)
-                word_dists[k,:] = temp.flatten()
-     
-            word_dists /= word_dists.sum(axis=1)[:, np.newaxis] # turn counts into probabilities     
-            if self.make_plot:
-                self._plot_nicely(word_dists, 'Topic Words', 'N', 'K')
-            return word_dists              
-        
-        def generate_document(self, word_dists, n_topics, vocab_size, document_length):
+    def __init__(self, alpha, make_plot=False):
+        self.alpha = alpha
+        self.make_plot = make_plot
 
-            # sample topic proportions with uniform dirichlet parameter alpha of length n_topics
-            theta = np.random.mtrand.dirichlet([self.alpha] * n_topics)
+    def generate_word_dists(self, n_topics, vocab_size, document_length):
 
-            # for every word in the vocab for this document
-            d = np.zeros(vocab_size)
-            for n in range(document_length):
-            
-                # sample a new topic index    
-                k = np.random.multinomial(1, theta).argmax()
-                
-                # sample a new word from the word distribution of topic k
-                w = np.random.multinomial(1, word_dists[k,:]).argmax()
+        width = vocab_size // n_topics
+        word_dists = np.zeros((n_topics, vocab_size))
 
-                # increase the occurrence of word w in document d
-                d[w] += 1
+        for k in range(n_topics):
+            temp = np.zeros((n_topics, width))
+            temp[k, :] = int(document_length / width)
+            word_dists[k, :] = temp.flatten()
 
-            return d
-        
-        def generate_input_df(self, n_topics, vocab_size, document_length, n_docs, 
-                              vocab_prefix=None, df_outfile=None, vocab_outfile=None):
-                        
-            print("Generating input DF")
-                        
-            # word_dists is the topic x document_length matrix
-            word_dists = self.generate_word_dists(n_topics, vocab_size, document_length)                        
-            
-            # generate each document x terms vector
-            docs = np.zeros((vocab_size, n_docs), dtype=int64)
-            for i in range(n_docs):
-                docs[:, i] = self.generate_document(word_dists, n_topics, vocab_size, document_length)
+        word_dists /= word_dists.sum(axis=1)[:, np.newaxis]
+        # turn counts into probabilities
+        if self.make_plot:
+            self._plot_nicely(word_dists, "Topic Words", "N", "K")
+        return word_dists
 
-            df = DataFrame(docs)
-            df = df.transpose()
-            print(df.shape )           
-            if self.make_plot:            
-                self._plot_nicely(df, 'Documents X Terms', 'Terms', 'Docs')
-            
-            if df_outfile is not None:
-                df.to_csv(df_outfile)        
+    def generate_document(
+        self,
+        word_dists,
+        n_topics,
+        vocab_size,
+        document_length,
+    ):
 
-            print("Generating vocabularies")
-            vocab = []
+        # sample topic proportions with uniform dirichlet parameter alpha
+        # of length n_topics
+        theta = np.random.mtrand.dirichlet([self.alpha] * n_topics)
 
-            # add new words
-            for n in range(vocab_size):
-                if vocab_prefix is None:
-                    word = "word_" + str(n)
-                else:
-                    word = vocab_prefix + "_word_" + str(n)
-                    vocab.append(word)
-            
-            # save to txt
-            vocab = np.array(vocab)
-            if vocab_outfile is not None:
-                np.savetxt(vocab_outfile, vocab, fmt='%s')
-            
-            return df, vocab
-        
-        def generate_from_file(self, df_infile, vocab_infile):
-            
-            # read data frame
-            df = pd.read_csv(df_infile, index_col=0)
+        # for every word in the vocab for this document
+        d = np.zeros(vocab_size)
+        for n in range(document_length):
 
-            # here we need to change column type from string to integer for 
-            # other parts in gibbs sampling to work ...
-            # TODO: check why, because this means we cannot set the column 
-            # names in the dataframe to the words!
-            df.rename(columns = lambda x: int(x), inplace=True)
-            
-            vocab = np.genfromtxt(vocab_infile, dtype='str')
-            return df, vocab
-        
-        def _plot_nicely(self, mat, title, xlabel, ylabel, outfile=None):
-            fig = plt.figure()
-            ax = fig.add_subplot(111)
-            im = ax.matshow(mat)
-            ax.set_title(title)
-            ax.set_xlabel(xlabel)
-            ax.set_ylabel(ylabel)
-            ax.set_aspect(2)
-            ax.set_aspect('auto')
-            plt.colorbar(im)
-            if outfile is not None:
-                plt.savefig(outfile)
-            plt.show()
+            # sample a new topic index
+            k = np.random.multinomial(1, theta).argmax()
+
+            # sample a new word from the word distribution of topic k
+            w = np.random.multinomial(1, word_dists[k, :]).argmax()
+
+            # increase the occurrence of word w in document d
+            d[w] += 1
+
+        return d
+
+    def generate_input_df(
+        self,
+        n_topics,
+        vocab_size,
+        document_length,
+        n_docs,
+        vocab_prefix=None,
+        df_outfile=None,
+        vocab_outfile=None,
+    ):
+
+        print("Generating input DF")
+
+        # word_dists is the topic x document_length matrix
+        word_dists = self.generate_word_dists(
+            n_topics,
+            vocab_size,
+            document_length,
+        )
+
+        # generate each document x terms vector
+        docs = np.zeros((vocab_size, n_docs), dtype=int64)
+        for i in range(n_docs):
+            docs[:, i] = self.generate_document(
+                word_dists,
+                n_topics,
+                vocab_size,
+                document_length,
+            )
+
+        # build vocabulary and use it as column names
+        vocab = []
+        for n in range(vocab_size):
+            if vocab_prefix is None:
+                word = "word_" + str(n)
+            else:
+                word = vocab_prefix + "_word_" + str(n)
+            vocab.append(word)
+
+        df = DataFrame(docs.T, columns=vocab)
+        print(df.shape)
+        if self.make_plot:
+            self._plot_nicely(df, "Documents X Terms", "Terms", "Docs")
+
+        if df_outfile is not None:
+            df.to_csv(df_outfile)
+        print("Generating vocabularies")
+
+        # save to txt
+        vocab = np.array(vocab)
+        if vocab_outfile is not None:
+            np.savetxt(vocab_outfile, vocab, fmt="%s")
+
+        return df, vocab
+
+    def generate_from_file(self, df_infile, vocab_infile):
+        """Load a document-term matrix and vocabulary from disk.
+
+        Column names are kept as words. When using this matrix with the
+        sampler, map the words to integer token IDs before constructing the
+        corpus.
+        """
+
+        # read data frame with word columns intact
+        df = pd.read_csv(df_infile, index_col=0)
+
+        vocab = np.genfromtxt(vocab_infile, dtype="str")
+        return df, vocab
+
+    def _plot_nicely(self, mat, title, xlabel, ylabel, outfile=None):
+        fig = plt.figure()
+        ax = fig.add_subplot(111)
+        im = ax.matshow(mat)
+        ax.set_title(title)
+        ax.set_xlabel(xlabel)
+        ax.set_ylabel(ylabel)
+        ax.set_aspect(2)
+        ax.set_aspect("auto")
+        plt.colorbar(im)
+        if outfile is not None:
+            plt.savefig(outfile)
+        plt.show()
 
 
 def main():
@@ -123,7 +147,13 @@ def main():
     vocab_size = 25
     document_length = 1000
     n_docs = 100
-    df, vocab = gen.generate_input_df(n_topics, vocab_size, document_length, n_docs)
+    df, vocab = gen.generate_input_df(
+        n_topics,
+        vocab_size,
+        document_length,
+        n_docs,
+    )
+
 
 if __name__ == "__main__":
     main()

--- a/notebooks/synth_data_test.ipynb
+++ b/notebooks/synth_data_test.ipynb
@@ -2,10 +2,9 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": null,
+   "id": "4d018f92",
+   "metadata": {},
    "outputs": [],
    "source": [
     "%load_ext autoreload\n",
@@ -13,7 +12,7 @@
     "%matplotlib inline\n",
     "\n",
     "import sys\n",
-    "basedir = '../'\n",
+    "basedir = \"../src\"\n",
     "sys.path.append(basedir)\n",
     "\n",
     "import numpy as np\n",
@@ -27,6 +26,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "51e77f7e",
    "metadata": {},
    "source": [
     "Synthetic data test for hierarchical LDA inference."
@@ -34,6 +34,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "61f6fe70",
    "metadata": {},
    "source": [
     "# 1. Generate Vocab"
@@ -41,73 +42,37 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[['w0' 'w1' 'w2' 'w3' 'w4']\n",
-      " ['w5' 'w6' 'w7' 'w8' 'w9']\n",
-      " ['w10' 'w11' 'w12' 'w13' 'w14']\n",
-      " ['w15' 'w16' 'w17' 'w18' 'w19']\n",
-      " ['w20' 'w21' 'w22' 'w23' 'w24']\n",
-      " ['w25' 'w26' 'w27' 'w28' 'w29']\n",
-      " ['w30' 'w31' 'w32' 'w33' 'w34']\n",
-      " ['w35' 'w36' 'w37' 'w38' 'w39']\n",
-      " ['w40' 'w41' 'w42' 'w43' 'w44']\n",
-      " ['w45' 'w46' 'w47' 'w48' 'w49']\n",
-      " ['w50' 'w51' 'w52' 'w53' 'w54']\n",
-      " ['w55' 'w56' 'w57' 'w58' 'w59']\n",
-      " ['w60' 'w61' 'w62' 'w63' 'w64']\n",
-      " ['w65' 'w66' 'w67' 'w68' 'w69']\n",
-      " ['w70' 'w71' 'w72' 'w73' 'w74']\n",
-      " ['w75' 'w76' 'w77' 'w78' 'w79']\n",
-      " ['w80' 'w81' 'w82' 'w83' 'w84']\n",
-      " ['w85' 'w86' 'w87' 'w88' 'w89']\n",
-      " ['w90' 'w91' 'w92' 'w93' 'w94']\n",
-      " ['w95' 'w96' 'w97' 'w98' 'w99']]\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "id": "a65b372e",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "n_rows = 20\n",
     "n_cols = 5\n",
-    "vocab_mat = np.zeros((n_rows, n_cols), dtype=np.object)\n",
+    "vocab_mat = np.zeros((n_rows, n_cols), dtype=object)\n",
     "word_count = 0\n",
     "for i in range(n_rows):\n",
     "    for j in range(n_cols):\n",
     "        vocab_mat[i, j] = 'w%s' % word_count\n",
     "        word_count += 1\n",
     "        \n",
-    "print vocab_mat"
+    "print(vocab_mat)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "['w0', 'w1', 'w2', 'w3', 'w4', 'w5', 'w6', 'w7', 'w8', 'w9', 'w10', 'w11', 'w12', 'w13', 'w14', 'w15', 'w16', 'w17', 'w18', 'w19', 'w20', 'w21', 'w22', 'w23', 'w24', 'w25', 'w26', 'w27', 'w28', 'w29', 'w30', 'w31', 'w32', 'w33', 'w34', 'w35', 'w36', 'w37', 'w38', 'w39', 'w40', 'w41', 'w42', 'w43', 'w44', 'w45', 'w46', 'w47', 'w48', 'w49', 'w50', 'w51', 'w52', 'w53', 'w54', 'w55', 'w56', 'w57', 'w58', 'w59', 'w60', 'w61', 'w62', 'w63', 'w64', 'w65', 'w66', 'w67', 'w68', 'w69', 'w70', 'w71', 'w72', 'w73', 'w74', 'w75', 'w76', 'w77', 'w78', 'w79', 'w80', 'w81', 'w82', 'w83', 'w84', 'w85', 'w86', 'w87', 'w88', 'w89', 'w90', 'w91', 'w92', 'w93', 'w94', 'w95', 'w96', 'w97', 'w98', 'w99']\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "id": "5513e165",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "vocab = vocab_mat.flatten().tolist()\n",
-    "print vocab"
+    "print(vocab)"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "09066531",
    "metadata": {},
    "source": [
     "# 2. Assign Documents to Tree"
@@ -115,30 +80,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "11\n",
-      "node 0 (level=0, documents=100): \n",
-      "    node 1 (level=1, documents=56): \n",
-      "        node 2 (level=2, documents=23): \n",
-      "        node 5 (level=2, documents=31): \n",
-      "        node 10 (level=2, documents=2): \n",
-      "    node 3 (level=1, documents=35): \n",
-      "        node 4 (level=2, documents=28): \n",
-      "        node 6 (level=2, documents=7): \n",
-      "    node 7 (level=1, documents=9): \n",
-      "        node 8 (level=2, documents=2): \n",
-      "        node 9 (level=2, documents=7): \n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "id": "d15eb117",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "NCRPNode.total_nodes = 0\n",
     "NCRPNode.last_node_id = 0\n",
@@ -153,7 +98,7 @@
     "for d in range(num_docs):\n",
     "\n",
     "    # populate nodes into the path of this document\n",
-    "    path = np.zeros(num_levels, dtype=np.object)\n",
+    "    path = np.zeros(num_levels, dtype=object)\n",
     "    path[0] = root_node\n",
     "    root_node.customers += 1 # always add to the root node first\n",
     "    for level in range(1, num_levels):\n",
@@ -168,7 +113,7 @@
     "    document_path[d] = path\n",
     "    \n",
     "unique_nodes = sorted(unique_nodes, key=lambda x: x.node_id)\n",
-    "print len(unique_nodes)\n",
+    "print(len(unique_nodes))\n",
     "    \n",
     "def print_node(node, indent, node_topic):\n",
     "    out = '    ' * indent\n",
@@ -176,7 +121,7 @@
     "    if node in node_topic:\n",
     "        probs, words = node_topic[node]\n",
     "        out += ' '.join(words)\n",
-    "    print out        \n",
+    "    print(out)        \n",
     "    for child in node.children:\n",
     "        print_node(child, indent+1, node_topic)        \n",
     "\n",
@@ -186,6 +131,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "1071f96c",
    "metadata": {},
    "source": [
     "# 3. Assign Each Node Along the Tree to a Topic"
@@ -193,25 +139,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[ 0.00040692  0.03688672  0.09907082  0.02081315  0.0340949   0.06334867\n",
-      "  0.05575553  0.00243414  0.01760897  0.09163744  0.00026633  0.0544931\n",
-      "  0.04593761  0.20827443  0.01494573  0.00392205  0.05150066  0.07604774\n",
-      "  0.02063409  0.10192099]\n",
-      "['w0' 'w5' 'w10' 'w15' 'w20' 'w25' 'w30' 'w35' 'w40' 'w45' 'w50' 'w55'\n",
-      " 'w60' 'w65' 'w70' 'w75' 'w80' 'w85' 'w90' 'w95']\n",
-      "1.0\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "id": "cc84e9a7",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "def get_words(vocab_mat, eta, pos, dim):\n",
     "\n",
@@ -228,26 +159,17 @@
     "pos = 0\n",
     "eta = 1\n",
     "probs, words = get_words(vocab_mat, eta, pos, 'col')\n",
-    "print probs\n",
-    "print words\n",
-    "print np.sum(probs)"
+    "print(probs)\n",
+    "print(words)\n",
+    "print(np.sum(probs))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "11\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "id": "8cfb6350",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "node_topic = {}\n",
     "node_topic[unique_nodes[0]] = get_words(vocab_mat, eta, 0, 'row') \n",
@@ -261,40 +183,22 @@
     "node_topic[unique_nodes[8]] = get_words(vocab_mat, eta, 8, 'row') \n",
     "node_topic[unique_nodes[9]] = get_words(vocab_mat, eta, 9, 'row') \n",
     "node_topic[unique_nodes[10]] = get_words(vocab_mat, eta, 10, 'row') \n",
-    "print len(node_topic)"
+    "print(len(node_topic))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "node 0 (level=0, documents=100): w0 w1 w2 w3 w4\n",
-      "    node 1 (level=1, documents=56): w5 w6 w7 w8 w9\n",
-      "        node 2 (level=2, documents=23): w10 w11 w12 w13 w14\n",
-      "        node 5 (level=2, documents=31): w25 w26 w27 w28 w29\n",
-      "        node 10 (level=2, documents=2): w50 w51 w52 w53 w54\n",
-      "    node 3 (level=1, documents=35): w15 w16 w17 w18 w19\n",
-      "        node 4 (level=2, documents=28): w20 w21 w22 w23 w24\n",
-      "        node 6 (level=2, documents=7): w30 w31 w32 w33 w34\n",
-      "    node 7 (level=1, documents=9): w35 w36 w37 w38 w39\n",
-      "        node 8 (level=2, documents=2): w40 w41 w42 w43 w44\n",
-      "        node 9 (level=2, documents=7): w45 w46 w47 w48 w49\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "id": "e0164fe1",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "print_node(root_node, 0, node_topic)"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "d0688929",
    "metadata": {},
    "source": [
     "# 4. Generate Words in a Document Based on Its Path"
@@ -302,10 +206,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": null,
+   "id": "495a3769",
+   "metadata": {},
    "outputs": [],
    "source": [
     "def generate_document(topics, theta, doc_len):\n",
@@ -329,10 +232,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": null,
+   "id": "ed23cda3",
+   "metadata": {},
    "outputs": [],
    "source": [
     "corpus = []\n",
@@ -349,10 +251,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": null,
+   "id": "a2d2a6cc",
+   "metadata": {},
    "outputs": [],
    "source": [
     "import os\n",
@@ -368,6 +269,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "a2e04ed3",
    "metadata": {},
    "source": [
     "# 5. Run hLDA"
@@ -375,25 +277,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "100 100 50\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "id": "6b180346",
+   "metadata": {},
+   "outputs": [],
    "source": [
-    "print len(vocab), len(corpus), len(corpus[0])"
+    "print(len(vocab), len(corpus), len(corpus[0]))"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "f09cdea6",
    "metadata": {},
    "source": [
     "convert corpus words into indices"
@@ -401,10 +295,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": null,
+   "id": "a228f695",
+   "metadata": {},
    "outputs": [],
    "source": [
     "new_corpus = []\n",
@@ -418,33 +311,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "100 100\n",
-      "['w4', 'w13', 'w7', 'w4', 'w9', 'w4', 'w1', 'w4', 'w7', 'w6', 'w14', 'w13', 'w4', 'w4', 'w7', 'w8', 'w4', 'w3', 'w3', 'w2', 'w6', 'w4', 'w8', 'w2', 'w4', 'w14', 'w4', 'w4', 'w2', 'w4', 'w12', 'w4', 'w7', 'w4', 'w3', 'w2', 'w1', 'w10', 'w1', 'w7', 'w2', 'w12', 'w9', 'w13', 'w9', 'w3', 'w6', 'w2', 'w2', 'w10']\n",
-      "[4, 13, 7, 4, 9, 4, 1, 4, 7, 6, 14, 13, 4, 4, 7, 8, 4, 3, 3, 2, 6, 4, 8, 2, 4, 14, 4, 4, 2, 4, 12, 4, 7, 4, 3, 2, 1, 10, 1, 7, 2, 12, 9, 13, 9, 3, 6, 2, 2, 10]\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "id": "e622ccff",
+   "metadata": {},
+   "outputs": [],
    "source": [
-    "print len(vocab), len(new_corpus)\n",
-    "print corpus[0]\n",
-    "print new_corpus[0]"
+    "print(len(vocab), len(new_corpus))\n",
+    "print(corpus[0])\n",
+    "print(new_corpus[0])"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": null,
+   "id": "e0f85747",
+   "metadata": {},
    "outputs": [],
    "source": [
     "from hlda.sampler import HierarchicalLDA"
@@ -452,162 +333,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[1.0, 1.0, 1.0] 1 1\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "id": "09d33a70",
+   "metadata": {},
+   "outputs": [],
    "source": [
-    "print alpha, gamma, eta"
+    "print(alpha, gamma, eta)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
-   "metadata": {
-    "collapsed": false,
-    "scrolled": false
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "HierarchicalLDA sampling\n",
-      "\n",
-      ".......... 10\n",
-      "topic=0 level=0 (documents=100): w4, w3, w2, w1, w9, \n",
-      "    topic=1 level=1 (documents=36): w4, w2, w3, w19, w17, \n",
-      "        topic=2 level=2 (documents=27): w20, w24, w22, w17, w23, \n",
-      "        topic=12 level=2 (documents=9): w12, w13, w6, w10, w14, \n",
-      "    topic=4 level=1 (documents=64): w29, w7, w8, w6, w25, \n",
-      "        topic=5 level=2 (documents=26): w6, w7, w9, w8, w5, \n",
-      "        topic=6 level=2 (documents=19): w25, w29, w28, w26, w6, \n",
-      "        topic=8 level=2 (documents=10): w17, w16, w19, w33, w15, \n",
-      "        topic=9 level=2 (documents=8): w49, w36, w39, w47, w46, \n",
-      "        topic=23 level=2 (documents=1): w43, w41, w42, w2, w44, \n",
-      "\n",
-      ".......... 20\n",
-      "topic=0 level=0 (documents=100): w4, w3, w2, w1, w0, \n",
-      "    topic=1 level=1 (documents=38): w50, w52, w6, w7, w17, \n",
-      "        topic=2 level=2 (documents=28): w20, w24, w22, w17, w19, \n",
-      "        topic=12 level=2 (documents=9): w12, w13, w10, w14, w6, \n",
-      "        topic=33 level=2 (documents=1): w43, w41, w42, w4, w44, \n",
-      "    topic=4 level=1 (documents=62): w7, w25, w8, w29, w6, \n",
-      "        topic=5 level=2 (documents=27): w6, w9, w7, w8, w12, \n",
-      "        topic=6 level=2 (documents=18): w29, w25, w28, w26, w6, \n",
-      "        topic=8 level=2 (documents=9): w17, w16, w19, w33, w15, \n",
-      "        topic=9 level=2 (documents=8): w49, w36, w39, w47, w46, \n",
-      "\n",
-      ".......... 30\n",
-      "topic=0 level=0 (documents=100): w4, w3, w2, w1, w0, \n",
-      "    topic=1 level=1 (documents=36): w50, w6, w52, w7, w9, \n",
-      "        topic=2 level=2 (documents=27): w20, w24, w22, w17, w19, \n",
-      "        topic=12 level=2 (documents=7): w12, w13, w10, w14, w6, \n",
-      "        topic=43 level=2 (documents=2): w43, w41, w42, w44, w40, \n",
-      "    topic=4 level=1 (documents=64): w6, w7, w9, w8, w29, \n",
-      "        topic=5 level=2 (documents=28): w6, w7, w9, w12, w8, \n",
-      "        topic=6 level=2 (documents=18): w25, w29, w28, w26, w27, \n",
-      "        topic=8 level=2 (documents=9): w17, w16, w19, w33, w15, \n",
-      "        topic=9 level=2 (documents=9): w49, w36, w39, w47, w35, \n",
-      "\n",
-      ".......... 40\n",
-      "topic=0 level=0 (documents=100): w4, w3, w2, w1, w0, \n",
-      "    topic=1 level=1 (documents=35): w6, w9, w7, w8, w29, \n",
-      "        topic=2 level=2 (documents=27): w24, w20, w22, w17, w19, \n",
-      "        topic=12 level=2 (documents=7): w12, w13, w10, w14, w6, \n",
-      "        topic=53 level=2 (documents=1): w43, w41, w42, w3, w40, \n",
-      "    topic=4 level=1 (documents=65): w6, w7, w9, w8, w25, \n",
-      "        topic=5 level=2 (documents=25): w6, w7, w9, w12, w8, \n",
-      "        topic=6 level=2 (documents=20): w29, w25, w28, w26, w27, \n",
-      "        topic=8 level=2 (documents=9): w17, w16, w19, w33, w15, \n",
-      "        topic=9 level=2 (documents=10): w49, w36, w39, w47, w35, \n",
-      "        topic=54 level=2 (documents=1): w99, w36, w26, w27, w28, \n",
-      "\n",
-      ".......... 50\n",
-      "topic=0 level=0 (documents=100): w4, w3, w2, w1, w25, \n",
-      "    topic=1 level=1 (documents=37): w7, w6, w9, w8, w5, \n",
-      "        topic=2 level=2 (documents=27): w20, w24, w22, w17, w19, \n",
-      "        topic=12 level=2 (documents=10): w12, w13, w10, w14, w6, \n",
-      "    topic=4 level=1 (documents=63): w6, w7, w9, w8, w5, \n",
-      "        topic=5 level=2 (documents=20): w6, w9, w7, w12, w13, \n",
-      "        topic=6 level=2 (documents=23): w29, w25, w28, w26, w27, \n",
-      "        topic=8 level=2 (documents=10): w17, w16, w19, w33, w15, \n",
-      "        topic=9 level=2 (documents=8): w49, w36, w39, w47, w35, \n",
-      "        topic=61 level=2 (documents=2): w43, w41, w42, w54, w39, \n",
-      "\n",
-      ".......... 60\n",
-      "topic=0 level=0 (documents=100): w4, w3, w2, w1, w0, \n",
-      "    topic=1 level=1 (documents=41): w6, w9, w7, w8, w50, \n",
-      "        topic=2 level=2 (documents=28): w24, w20, w22, w17, w23, \n",
-      "        topic=12 level=2 (documents=11): w12, w13, w10, w14, w11, \n",
-      "        topic=72 level=2 (documents=2): w43, w41, w42, w2, w44, \n",
-      "    topic=4 level=1 (documents=59): w6, w7, w9, w8, w5, \n",
-      "        topic=5 level=2 (documents=13): w12, w6, w13, w7, w10, \n",
-      "        topic=6 level=2 (documents=27): w29, w25, w28, w26, w27, \n",
-      "        topic=8 level=2 (documents=9): w17, w16, w19, w33, w15, \n",
-      "        topic=9 level=2 (documents=10): w49, w36, w39, w47, w46, \n",
-      "\n",
-      ".......... 70\n",
-      "topic=0 level=0 (documents=100): w4, w3, w2, w1, w0, \n",
-      "    topic=1 level=1 (documents=52): w6, w9, w7, w8, w5, \n",
-      "        topic=2 level=2 (documents=29): w20, w24, w22, w17, w19, \n",
-      "        topic=12 level=2 (documents=19): w12, w13, w10, w14, w11, \n",
-      "        topic=81 level=2 (documents=4): w43, w41, w42, w40, w39, \n",
-      "    topic=4 level=1 (documents=48): w6, w7, w9, w8, w5, \n",
-      "        topic=6 level=2 (documents=29): w25, w29, w28, w26, w27, \n",
-      "        topic=8 level=2 (documents=9): w17, w16, w19, w33, w15, \n",
-      "        topic=9 level=2 (documents=8): w49, w36, w39, w47, w35, \n",
-      "        topic=75 level=2 (documents=2): w50, w52, w53, w54, w3, \n",
-      "\n",
-      ".......... 80\n",
-      "topic=0 level=0 (documents=100): w4, w3, w2, w1, w29, \n",
-      "    topic=1 level=1 (documents=52): w6, w7, w9, w8, w5, \n",
-      "        topic=2 level=2 (documents=26): w20, w24, w22, w17, w19, \n",
-      "        topic=12 level=2 (documents=20): w12, w13, w10, w14, w11, \n",
-      "        topic=88 level=2 (documents=5): w50, w52, w53, w6, w54, \n",
-      "        topic=89 level=2 (documents=1): w43, w41, w42, w2, w44, \n",
-      "    topic=4 level=1 (documents=48): w6, w7, w9, w8, w5, \n",
-      "        topic=6 level=2 (documents=29): w25, w29, w28, w26, w27, \n",
-      "        topic=8 level=2 (documents=10): w17, w16, w19, w33, w15, \n",
-      "        topic=9 level=2 (documents=9): w49, w36, w39, w47, w35, \n",
-      "\n",
-      ".......... 90\n",
-      "topic=0 level=0 (documents=100): w4, w3, w2, w1, w9, \n",
-      "    topic=1 level=1 (documents=47): w6, w7, w9, w8, w5, \n",
-      "        topic=2 level=2 (documents=26): w20, w24, w22, w17, w19, \n",
-      "        topic=12 level=2 (documents=18): w12, w13, w10, w14, w11, \n",
-      "        topic=88 level=2 (documents=3): w50, w52, w53, w54, w3, \n",
-      "    topic=4 level=1 (documents=53): w6, w7, w9, w8, w5, \n",
-      "        topic=6 level=2 (documents=30): w29, w25, w28, w26, w27, \n",
-      "        topic=8 level=2 (documents=11): w17, w16, w19, w33, w15, \n",
-      "        topic=9 level=2 (documents=9): w49, w36, w39, w47, w35, \n",
-      "        topic=97 level=2 (documents=3): w43, w41, w42, w44, w39, \n",
-      "\n",
-      ".......... 100\n",
-      "topic=0 level=0 (documents=100): w4, w3, w2, w1, w0, \n",
-      "    topic=1 level=1 (documents=48): w6, w7, w9, w8, w12, \n",
-      "        topic=2 level=2 (documents=28): w20, w24, w22, w17, w19, \n",
-      "        topic=12 level=2 (documents=18): w12, w13, w10, w14, w11, \n",
-      "        topic=105 level=2 (documents=2): w50, w52, w53, w54, w3, \n",
-      "    topic=4 level=1 (documents=52): w6, w7, w9, w8, w5, \n",
-      "        topic=6 level=2 (documents=30): w29, w25, w28, w26, w27, \n",
-      "        topic=8 level=2 (documents=11): w17, w16, w19, w33, w15, \n",
-      "        topic=9 level=2 (documents=8): w49, w36, w39, w47, w35, \n",
-      "        topic=101 level=2 (documents=1): w99, w36, w26, w27, w28, \n",
-      "        topic=103 level=2 (documents=2): w43, w41, w42, w2, w4, \n",
-      "\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "id": "4d6d46a2",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "n_samples = 100\n",
     "hlda = HierarchicalLDA(new_corpus, vocab, alpha=1, gamma=1.0, eta=1.0, num_levels=3)\n",
@@ -617,32 +356,19 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "id": "ee23da71",
+   "metadata": {},
    "outputs": [],
    "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 2
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.13"
+   "name": "python3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 5
 }


### PR DESCRIPTION
## Summary
- allow textual column names in `synth_data.py`
- clarify how to load data with word columns
- reformat notebook and update kernel to Python 3

## Testing
- `pre-commit run --files notebooks/synth_data.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6840e14fd3fc83269b9ddb974505c52d