### PR TITLE
Add tree export feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,13 @@ If you installed the package from PyPI you can run the same demo via the
 hlda-demo --data-dir data/bbc/tech --iterations 20
 ```
 
+To write the learned hierarchy to disk in JSON format, pass
+`--export-tree <file>` when running the script:
+
+```bash
+python scripts/run_hlda.py --data-dir data/bbc/tech --export-tree tree.json
+```
+
 If you make use of the BBC dataset, please cite the publication by Greene and
 Cunningham (2006) as detailed in [`CITATION.cff`](CITATION.cff).
 

--- a/scripts/run_hlda.py
+++ b/scripts/run_hlda.py
@@ -4,6 +4,7 @@ files."""
 
 import argparse
 import glob
+import json
 import os
 import re
 
@@ -115,6 +116,10 @@ def run_demo(args):
     print("\nFinal topic hierarchy:")
     hlda.print_nodes(args.n_words, with_weights=False)
 
+    if getattr(args, "export_tree", None):
+        with open(args.export_tree, "w", encoding="utf-8") as f:
+            json.dump(hlda.export_tree(), f, indent=2)
+
     return hlda
 
 
@@ -172,6 +177,11 @@ def main():
         type=int,
         default=0,
         help="Random seed",
+    )
+    parser.add_argument(
+        "--export-tree",
+        metavar="FILE",
+        help="Write the final hierarchy as JSON to FILE",
     )
 
     args = parser.parse_args()

--- a/src/hlda/sampler.py
+++ b/src/hlda/sampler.py
@@ -502,6 +502,20 @@ class HierarchicalLDA(object):
         for child in node.children:
             self.print_node(child, indent+1, n_words, with_weights)
 
+    def export_tree(self):
+        """Return the current hierarchy as a JSON‑serialisable structure."""
+
+        def visit(node):
+            return {
+                "id": int(node.node_id),
+                "level": int(node.level),
+                "customers": int(node.customers),
+                "total_words": int(node.total_words),
+                "children": [visit(child) for child in node.children],
+            }
+
+        return visit(self.root_node)
+
 
 def load_vocab(file_name):
     with open(file_name, 'r', encoding='utf-8', newline='') as f:

--- a/tests/test_export_tree_json.py
+++ b/tests/test_export_tree_json.py
@@ -1,0 +1,36 @@
+import argparse
+import json
+import os
+import sys
+from importlib import import_module
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, ROOT)
+sys.path.insert(0, os.path.join(ROOT, "src"))
+
+run_hlda = import_module("scripts.run_hlda")
+
+
+def test_export_tree(tmp_path):
+    (tmp_path / "doc1.txt").write_text("First document about cats.")
+    (tmp_path / "doc2.txt").write_text("Second document about dogs.")
+
+    output_file = tmp_path / "tree.json"
+    args = argparse.Namespace(
+        data_dir=str(tmp_path),
+        iterations=1,
+        display_topics=1,
+        n_words=2,
+        num_levels=3,
+        alpha=1.0,
+        gamma=1.0,
+        eta=0.1,
+        seed=0,
+        export_tree=str(output_file),
+    )
+
+    run_hlda.run_demo(args)
+    data = json.loads(output_file.read_text())
+
+    assert data["level"] == 0
+    assert isinstance(data["children"], list)


### PR DESCRIPTION
## Summary
- export NCRP tree as JSON via `HierarchicalLDA.export_tree`
- expose `--export-tree` CLI option in `run_hlda.py`
- document JSON export in README
- test exporting hierarchy to JSON

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840e154e7108326811f86be7fe2bebb